### PR TITLE
exports: fix the top-level export to be the class itself

### DIFF
--- a/lib/moment-parser.js
+++ b/lib/moment-parser.js
@@ -3,7 +3,6 @@ var parser = require('./parser');
 var MomentGenerator = require('./moment-generator');
 
 var MomentParser = Base.extend({
-
     initialize: function(options) {
         options = options || {};
         this.debug = !!options.debug;
@@ -30,7 +29,5 @@ var MomentParser = Base.extend({
     }
 });
 
-module.exports = {
-    MomentParser: MomentParser,
-    SyntaxError: parser.SyntaxError
-};
+module.exports = MomentParser;
+MomentParser.SyntaxError = SyntaxError

--- a/test/literal-durations.spec.js
+++ b/test/literal-durations.spec.js
@@ -1,4 +1,4 @@
-var MomentParser = require('..').MomentParser;
+var MomentParser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 

--- a/test/literal-moments.spec.js
+++ b/test/literal-moments.spec.js
@@ -1,4 +1,4 @@
-var MomentParser = require('..').MomentParser;
+var MomentParser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');


### PR DESCRIPTION
Include SyntaxError as an attribute of the prototype so it can be
referenced if needed, but this way at least the normal use case is
simpler.
