### PR TITLE
fix and test SyntaxError Export

### DIFF
--- a/lib/moment-parser.js
+++ b/lib/moment-parser.js
@@ -29,5 +29,5 @@ var MomentParser = Base.extend({
     }
 });
 
+MomentParser.SyntaxError = parser.SyntaxError;
 module.exports = MomentParser;
-MomentParser.SyntaxError = SyntaxError

--- a/test/literal-durations.spec.js
+++ b/test/literal-durations.spec.js
@@ -36,4 +36,11 @@ describe('literal durations', function() {
             expect(parser.parse(input)).deep.equal(output);
         });
     });
+
+    it('syntax error results from duration nonsense', function() {
+      function parseNonsense() {
+        parser.parse('1 nonesense');
+      }
+      expect(parseNonsense).to.throw(MomentParser.SyntaxError);
+    });
 });


### PR DESCRIPTION
- Mostly the `parser.SyntaxError` fix instead of including just `SyntaxError`.
- Also put the `= parser.SyntaxError` above the export. I realize it doesn't matter but feels nicer?
- Added a test.
