### PR TITLE
create a FormattedDuration AST type to handle mixed dotnet and month in a duration

### DIFF
--- a/lib/moment-generator.js
+++ b/lib/moment-generator.js
@@ -76,6 +76,7 @@ var MomentGenerator = ASTVisitor.extend({
 
     visit_TimeSpan: function(node) {
         return moment.duration({
+            milliseconds: node.milliseconds,
             seconds: node.seconds,
             minutes: node.minutes,
             hours: node.hours,

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -172,14 +172,15 @@ HumanDuration
     }
 
 TimeSpan
-    = months:(Integer "/")? days:(Integer ".")? hours:Integer ":" minutes:Integer ":" seconds:DecimalLiteral {
+    = months:(Integer "/")? days:(Integer ".")? hours:Integer2 ":" minutes:Integer2 ":" seconds:Integer2 ms:("." $(DecimalDigit DecimalDigit? DecimalDigit?))? {
         return {
             type: "TimeSpan",
             months: (months === null) ? 0 : months[0],
             days: (days === null) ? 0 : days[0],
-            hours: hours,
-            minutes: minutes,
-            seconds: seconds
+            hours: parseInt(hours),
+            minutes: parseInt(minutes),
+            seconds: parseInt(seconds),
+            milliseconds: (ms === null) ? 0 : parseInt(ms[1])
         };
     }
 

--- a/test/duration-literal-asts.spec.js
+++ b/test/duration-literal-asts.spec.js
@@ -68,6 +68,7 @@ describe('literal duration parsing as AST', function() {
 
         '01:23:45': {
             type: 'TimeSpan',
+            milliseconds: 0,
             seconds: 45,
             minutes: 23,
             hours: 1,
@@ -75,9 +76,10 @@ describe('literal duration parsing as AST', function() {
             months: 0
         },
 
-        '1/23.01:23:45.678': {
+        '1/23.01:23:45.067': {
             type: 'TimeSpan',
-            seconds: 45.678,
+            milliseconds: 67,
+            seconds: 45,
             minutes: 23,
             hours: 1,
             days: 23,

--- a/test/duration-literals.spec.js
+++ b/test/duration-literals.spec.js
@@ -17,10 +17,11 @@ describe('literal duration parsing as durations', function() {
         'PT4H5M': moment.duration('PT4H5M'),
         'P1Y2M': moment.duration('P1Y2M'),
         'P2MT5M': moment.duration('P2MT5M'),
+        '00:00:00.123': moment.duration('00:00:00.123'),
         '01:23:45': moment.duration('01:23:45'),
         '01:23:45.678': moment.duration('01:23:45.678'),
-        '23.01:23:45.678': moment.duration('23.01:23:45.678'),
-        '1/23.01:23:45.678': moment.duration('23.01:23:45.678').add(1, 'M')
+        '23.01:23:45.067': moment.duration('23.01:23:45.067'),
+        '1/23.01:23:45.067': moment.duration('23.01:23:45.067').add(1, 'M')
     };
 
     _.each(tests, function(duration, input) {
@@ -30,7 +31,13 @@ describe('literal duration parsing as durations', function() {
     });
 
     var throws = {
-        'forever': MomentParser.SyntaxError
+        'forever': MomentParser.SyntaxError,
+        '0:0:0': MomentParser.SyntaxError,
+        '000:00:00': MomentParser.SyntaxError,
+        '00:00:0.123': MomentParser.SyntaxError,
+        '1.5/23.01:23:45.678': MomentParser.SyntaxError,
+        '1.5/01:23:45.678': MomentParser.SyntaxError,
+        '1/23.01:23:45.0678':MomentParser.SyntaxError
     };
 
     _.each(throws, function(expected, input) {


### PR DESCRIPTION
this cleans up support for our literal duration format.

Background:
Because the ISO duration format is so hideous, we adopted the ASP.NET 
duration format of HH:MM:SS:UUU optionally prepended with a number
of days: DD.HH:MM:SS.UUU. We further extended this with an optional
month prefix: MM/DD.HH:MM:SS, so that month offsets are preserved as
calendar quantities.

The JuttleMoment module consumed these things directly, so the parser just
passed them through. We can't do that for moments. So have the parser break
apart the months from the ASP.NET part of the string (which momentjs consumes
directly).

Also, remove support for signed integers in these formatted durations, something we overrode
elsewhere in the grammar when we made a leading sign mean "relative to now".

@demmer
