### PR TITLE
add ISO8601 durations to be good citizens

### DIFF
--- a/lib/moment-generator.js
+++ b/lib/moment-generator.js
@@ -53,6 +53,10 @@ var MomentGenerator = ASTVisitor.extend({
         return moment.duration(node.value, node.unit);
     },
 
+    visit_ISODurationLiteral: function(node) {
+        return moment.duration(node.value);
+    },
+
     visit_BinaryExpression: function(node) {
         if (node.operator === '+') {
             return this.visit(node.left).add(this.visit(node.right));

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -65,11 +65,23 @@ ISODate
 ISOTime
     = $(Integer2 ":" Integer2 ":" Integer2 ("." DecimalDigits)?)
 
+ISODuration
+    = $("P" Integer "W")
+    / $("P" (Integer "Y")? (Integer "M")? (Integer "D")? ("T" (Integer "H")? (Integer "M")? (Integer "S")?)?)
+
 ISODateLiteral
     = d:ISODate t:$("T" ISOTime)? z:$ISOTZ? {
         return {
             type: "ISODateLiteral",
             value: d + (t? t : "T00:00:00") + (z ? z: "")
+        }
+    }
+
+ISODurationLiteral
+    = ISODuration {
+        return {
+            type: "ISODurationLiteral",
+            value: text()
         }
     }
 
@@ -300,6 +312,7 @@ DurationLiteral
     }
     / FormattedDuration
     / HumanDuration
+    / ISODurationLiteral
 
 DurationExpression
     = left:DurationLiteral _ "and" _ right:DurationExpression {

--- a/test/duration-literal-asts.spec.js
+++ b/test/duration-literal-asts.spec.js
@@ -31,6 +31,31 @@ describe('literal duration parsing as AST', function() {
             value: 1
         },
 
+        'P1W': {
+            type: 'ISODurationLiteral',
+            value: 'P1W'
+        },
+
+        'P1Y2M3DT4H5M6S': {
+            type: 'ISODurationLiteral',
+            value: 'P1Y2M3DT4H5M6S'
+        },
+
+        'PT4H5M': {
+            type: 'ISODurationLiteral',
+            value: 'PT4H5M'
+        },
+
+        'P1Y2M': {
+            type: 'ISODurationLiteral',
+            value: 'P1Y2M'
+        },
+
+        'P2MT5M': {
+            type: 'ISODurationLiteral',
+            value: 'P2MT5M'
+        },
+
         'forever': {
             type: 'ForeverLiteral',
         }

--- a/test/duration-literals.spec.js
+++ b/test/duration-literals.spec.js
@@ -10,7 +10,12 @@ describe('literal duration parsing as durations', function() {
         '1 hour': moment.duration(1,'h'),
         '100 s': moment.duration(100,'s'),
         '1.5d': moment.duration(1.5,'d'),
-        '1m': moment.duration(1,'m')
+        '1m': moment.duration(1,'m'),
+        'P1W': moment.duration('P1W'),
+        'P1Y2M3DT4H5M6S': moment.duration('P1Y2M3DT4H5M6S'),
+        'PT4H5M': moment.duration('PT4H5M'),
+        'P1Y2M': moment.duration('P1Y2M'),
+        'P2MT5M': moment.duration('P2MT5M')
     };
 
     _.each(tests, function(duration, input) {


### PR DESCRIPTION
it seemed poor form not to consume ISO8601 durations, even if they are horrible.
https://en.wikipedia.org/wiki/ISO_8601#Durations

the momentjs parser consumes these as literals, so in keeping with ISODateTime being an opaque string passed to the moment constructor, recognize an ISODuration string and pass it through to the duration constructor

@demmer 
