### PR TITLE
eliminate 'next n units / last n units' parsing rule

### DIFF
--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -241,9 +241,7 @@ CalendarExpression
             }
         };
     }
-    / ("prior" / "last") _ offset:(Integer _)? unit:( CalendarUnit / DurationUnit ) {
-        var num = (offset === null) ? 1 : offset[0];
-
+    / "last" _ unit:( CalendarUnit / DurationUnit ) {
         return {
             type: "CalendarExpression",
             direction: "down",
@@ -256,15 +254,13 @@ CalendarExpression
                 },
                 right: {
                    type: "MomentDuration",
-                   value: num,
+                   value: 1,
                    unit: unit
                }
             }
         };
     }
-    / "next" _ offset:(Integer _)? unit:( CalendarUnit / DurationUnit ) {
-        var num = (offset === null) ? 1 : offset[0];
-
+    / "next" _ unit:( CalendarUnit / DurationUnit ) {
         return {
             type: "CalendarExpression",
             direction: "down",
@@ -277,7 +273,7 @@ CalendarExpression
                 },
                 right: {
                    type: "MomentDuration",
-                   value: num,
+                   value: 1,
                    unit: unit
                }
             }

--- a/test/calendar-expressions.spec.js
+++ b/test/calendar-expressions.spec.js
@@ -25,4 +25,17 @@ describe('CalendarExpression parsing as moment', function() {
         });
     });
 
+    var throws = {
+        'last week of this year': MomentParser.SyntaxError // last != final!
+    };
+
+    _.each(throws, function(expected, input) {
+        it('fails on "' + input + '"', function() {
+            function parseInput() {
+                parser.parseAsMoment(input);
+            }
+            expect(parseInput).to.throw(expected);
+        });
+    });
+
 });

--- a/test/moment-expressions.spec.js
+++ b/test/moment-expressions.spec.js
@@ -19,6 +19,10 @@ describe('Full moment grammar expression parsing', function() {
             now.clone().subtract(1, 'minute'),
         '-M':
             now.clone().subtract(1, 'month'),
+        'last month':
+            now.clone().startOf('month').subtract(1, 'month'),
+        'next year':
+            now.clone().startOf('year').add(1, 'year'),
         '4 months after 2015-06-15':
             moment.utc('2015-06-15').add(4, 'month'),
     };
@@ -26,6 +30,20 @@ describe('Full moment grammar expression parsing', function() {
     _.each(tests, function(expected, input) {
         it('handles "' + input + '"', function() {
             expect(parser.parseAsMoment(input, {now: now}).isSame(expected)).is.true;
+        });
+    });
+
+    var throws = {
+        'last 3 months': MomentParser.SyntaxError,
+        'next 2 days': MomentParser.SyntaxError
+    };
+
+    _.each(throws, function(expected, input) {
+        it('fails on "' + input + '"', function() {
+            function parseInput() {
+                parser.parseAsMoment(input);
+            }
+            expect(parseInput).to.throw(expected);
         });
     });
 


### PR DESCRIPTION
don't allow 'next 3 months or last 2 days, but do allow next month or last month.

tests will be added after pending PR#11 (expression-test) is approved for merge.
