### PR TITLE
add an acceptDuration option to the parseMoment API

### DIFF
--- a/lib/moment-parser.js
+++ b/lib/moment-parser.js
@@ -25,11 +25,15 @@ var MomentParser = Base.extend({
      * To support expressions that are relative to a "current" time, options.now
      * may contain a moment instance for the current time. It defaults
      * to the time of execution.
+     *
+     * An error is thrown if the input is actually a duration expression, unless
+     * options.acceptDuration is true.
      */
     parseMoment: function(source, options) {
+        options = options || {};
         var ast = this.parse(source);
         var moment = new MomentGenerator(options).visit(ast);
-        if (!moment._isAMomentObject) {
+        if (!moment._isAMomentObject && !options.acceptDuration) {
             throw new errors.NotAMomentError();
         }
         return moment;

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -23,6 +23,12 @@ describe('moment-parser API ', function() {
         }).to.throw(MomentParser.NotAMomentError);
     });
 
+    it('accepts durations when parsing a moment with acceptDuration=true', function() {
+        var duration = parser.parseMoment("30 seconds", {acceptDuration: true});
+        expect(duration).is.defined;
+        expect(duration.asMilliseconds()).equal(30000);
+    });
+
     it('rejects durations when expecting a date', function() {
         expect(function() {
             parser.parseDate("3 weeks");


### PR DESCRIPTION
To support cases in which a caller may not know ahead of time whether
an expression should return a moment or a duration, but wants the
parser to convert the input into a moment.js object, add support
for an acceptDuration option to the parseMoment API function.