### PR TITLE
add a valueType of either "moment" or "duration" to every AST node

### DIFF
--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -47,6 +47,7 @@ UnixTimeLiteral
     = s:DecimalLiteral !SourceCharacter {
         return {
             type: "UnixTimeLiteral",
+            valueType: "moment",
             value: s
         }
     }
@@ -70,6 +71,7 @@ ISODateLiteral
     = d:ISODate t:$("T" ISOTime)? z:$ISOTZ? {
         return {
             type: "ISODateLiteral",
+            valueType: "moment",
             value: d + (t? t : "T00:00:00") + (z ? z: "")
         }
     }
@@ -78,6 +80,7 @@ ISODurationLiteral
     = ISODuration {
         return {
             type: "ISODurationLiteral",
+            valueType: "duration",
             value: text()
         }
     }
@@ -85,14 +88,16 @@ ISODurationLiteral
 NowLiteral
     = "now" {
         return {
-            type: "NowLiteral"
+            type: "NowLiteral",
+            valueType: "moment"
         };
     }
 
 BeginningLiteral
     = "beginning" {
         return {
-            type: "BeginningLiteral"
+            type: "BeginningLiteral",
+            valueType: "moment"
         };
     }
 
@@ -100,7 +105,8 @@ BeginningLiteral
 EndLiteral
     = "end" {
         return {
-            type: "EndLiteral"
+            type: "EndLiteral",
+            valueType: "moment"
         };
     }
 
@@ -157,6 +163,7 @@ HumanDuration
     = num:Integer? _ unit:CalendarUnit {
         return {
             type: "MomentDuration",
+            valueType: "duration",
             value: (num === null) ? 1 : num,
             unit: unit
         };
@@ -166,6 +173,7 @@ HumanDuration
 
         return {
             type: "MomentDuration",
+            valueType: "duration",
             value: num,
             unit: unit
         };
@@ -175,6 +183,7 @@ TimeSpan
     = months:(Integer "/")? days:(Integer ".")? hours:Integer2 ":" minutes:Integer2 ":" seconds:Integer2 ms:("." $(DecimalDigit DecimalDigit? DecimalDigit?))? {
         return {
             type: "TimeSpan",
+            valueType: "duration",
             months: (months === null) ? 0 : months[0],
             days: (days === null) ? 0 : days[0],
             hours: parseInt(hours),
@@ -188,6 +197,7 @@ CalendarOffset
     = "first" _ unit:CalendarUnit _ "of" _ expr:CalendarExpression {
         return {
             type: "CalendarExpression",
+            valueType: "moment",
             direction: "down",
             unit: unit,
             expression: expr
@@ -196,6 +206,7 @@ CalendarOffset
     / "final" _ unit:CalendarUnit _ "of" _ expr:CalendarExpression {
         return {
             type: "CalendarExpression",
+            valueType: "moment",
             direction: "down",
             unit: unit,
             expression: {
@@ -209,6 +220,7 @@ CalendarOffset
     / ord:OrdinalOffset _ "of" _ expr:CalendarExpression {
         return {
             type: "BinaryExpression",
+            valueType: "moment",
             operator: "+",
             left: expr,
             right: ord
@@ -218,22 +230,26 @@ CalendarOffset
 CalendarExpression
     = "today" {
         return {
-            type: "TodayLiteral"
+            type: "TodayLiteral",
+            valueType: "moment"
         };
     }
     / "yesterday" {
         return {
-            type: "YesterdayLiteral"
+            type: "YesterdayLiteral",
+            valueType: "moment"
         };
     }
     / "tomorrow" {
         return {
-            type: "TomorrowLiteral"
+            type: "TomorrowLiteral",
+            valueType: "moment"
         };
     }
     / "this" _ unit:( CalendarUnit / DurationUnit ) {
         return {
             type: "CalendarExpression",
+            valueType: "moment",
             direction: "down",
             unit: unit,
             expression: {
@@ -244,6 +260,7 @@ CalendarExpression
     / "last" _ unit:( CalendarUnit / DurationUnit ) {
         return {
             type: "CalendarExpression",
+            valueType: "moment",
             direction: "down",
             unit: unit,
             expression: {
@@ -263,6 +280,7 @@ CalendarExpression
     / "next" _ unit:( CalendarUnit / DurationUnit ) {
         return {
             type: "CalendarExpression",
+            valueType: "moment",
             direction: "down",
             unit: unit,
             expression: {
@@ -282,6 +300,7 @@ CalendarExpression
     / unit:CalendarUnit _ "of" _ expr:MomentExpression {
         return {
             type: "CalendarExpression",
+            valueType: "moment",
             direction: "down",
             unit: unit,
             expression: expr
@@ -293,6 +312,7 @@ OrdinalOffset
     = unit:CalendarUnit _ offset:Integer {
         return {
             type: "MomentDuration",
+            valueType: "duration",
             value: offset - 1,
             unit: unit
         };
@@ -304,7 +324,8 @@ OrdinalDuration
 DurationLiteral
     = "forever" {
         return {
-            type: "ForeverLiteral"
+            type: "ForeverLiteral",
+            valueType: "duration"
         };
     }
     / TimeSpan
@@ -315,6 +336,7 @@ DurationExpression
     = left:DurationLiteral _ "and" _ right:DurationExpression {
         return {
             type: "BinaryExpression",
+            valueType: "duration",
             operator: "+",
             left: left,
             right: right
@@ -327,6 +349,7 @@ MomentExpression
     / "-" durationExpression:DurationExpression {
         return {
             type: "BinaryExpression",
+            valueType: "moment",
             operator: "-",
             left: {
                 type: "NowLiteral"
@@ -337,6 +360,7 @@ MomentExpression
     / "+" durationExpression:DurationExpression {
         return {
             type: "BinaryExpression",
+            valueType: "moment",
             operator: "+",
             left: {
                 type: "NowLiteral"
@@ -347,6 +371,7 @@ MomentExpression
     / durationExpression:DurationExpression _ "ago" {
         return {
             type: "BinaryExpression",
+            valueType: "moment",
             operator: "-",
             left: {
                 type: "NowLiteral"
@@ -357,6 +382,7 @@ MomentExpression
     / durationExpression:DurationExpression _ "before" _ subExpression:( MomentExpression / CalendarExpression / MomentValue ) {
         return {
             type: "BinaryExpression",
+            valueType: "moment",
             operator: "-",
             left: subExpression,
             right: durationExpression
@@ -365,6 +391,7 @@ MomentExpression
     / durationExpression:DurationExpression _ ("after" / "from") _ subExpression:( MomentExpression / CalendarExpression / MomentValue ) {
         return {
             type: "BinaryExpression",
+            valueType: "moment",
             operator: "+",
             left: subExpression,
             right: durationExpression

--- a/test/binary-expression-asts.spec.js
+++ b/test/binary-expression-asts.spec.js
@@ -9,12 +9,14 @@ describe('BinaryExpression parsing as AST', function() {
     var tests = {
         '+2h': {
             type: 'BinaryExpression',
+            valueType: 'moment',
             operator: '+',
             left: {
                 type: 'NowLiteral'
             },
             right: {
                 type: 'MomentDuration',
+                valueType: 'duration',
                 unit: "h",
                 value: 2
             }
@@ -23,11 +25,13 @@ describe('BinaryExpression parsing as AST', function() {
         '-12M': {
             type: 'BinaryExpression',
             operator: '-',
+            valueType: 'moment',
             left: {
                 type: 'NowLiteral'
             },
             right: {
                 type: 'MomentDuration',
+                valueType: 'duration',
                 unit: "M",
                 value: 12
             }
@@ -36,11 +40,13 @@ describe('BinaryExpression parsing as AST', function() {
         '2 minutes ago': {
             type: 'BinaryExpression',
             operator: '-',
+            valueType: 'moment',
             left: {
                 type: 'NowLiteral'
             },
             right: {
                 type: 'MomentDuration',
+                valueType: 'duration',
                 unit: "minute",
                 value: 2
             }
@@ -48,13 +54,16 @@ describe('BinaryExpression parsing as AST', function() {
 
         '2 minutes before 2015-01-01': {
             type: 'BinaryExpression',
+            valueType: 'moment',
             operator: '-',
             left: {
                 type: 'ISODateLiteral',
+                valueType: 'moment',
                 value: "2015-01-01T00:00:00"
             },
             right: {
                 type: 'MomentDuration',
+                valueType: 'duration',
                 unit: "minute",
                 value: 2
             }
@@ -62,13 +71,16 @@ describe('BinaryExpression parsing as AST', function() {
 
         '3 days after 2015-01-01': {
             type: 'BinaryExpression',
+            valueType: 'moment',
             operator: '+',
             left: {
                 type: 'ISODateLiteral',
+                valueType: 'moment',
                 value: "2015-01-01T00:00:00"
             },
             right: {
                 type: 'MomentDuration',
+                valueType: 'duration',
                 unit: "day",
                 value: 3
             }
@@ -76,22 +88,27 @@ describe('BinaryExpression parsing as AST', function() {
 
         '6 hours and 2 minutes and 30 seconds': {
             type: 'BinaryExpression',
+            valueType: 'duration',
             operator: '+',
             left: {
                 type: 'MomentDuration',
+                valueType: 'duration',
                 unit: "hour",
                 value: 6
             },
             right: {
                 type: 'BinaryExpression',
+                valueType: 'duration',
                 operator: '+',
                 left: {
                     type: 'MomentDuration',
+                    valueType: 'duration',
                     unit: "minute",
                     value: 2
                 },
                 right: {
                     type: 'MomentDuration',
+                    valueType: 'duration',
                     unit: "second",
                     value: 30
                 }

--- a/test/binary-expressions.spec.js
+++ b/test/binary-expressions.spec.js
@@ -30,6 +30,7 @@ describe('BinaryExpression parsing as moment', function() {
 
     _.each(tests, function(expected, input) {
         it('handles "' + input + '"', function() {
+            expect(parser.parse(input).valueType).equal('moment');
             expect(is_same(expected, parser.parseMoment(input, {now: now}))).is.true;
         });
     });
@@ -42,6 +43,7 @@ describe('BinaryExpression parsing as duration', function() {
 
     _.each(tests, function(expected, input) {
         it('handles "' + input + '"', function() {
+            expect(parser.parse(input).valueType).equal('duration');
             expect(is_same(expected, parser.parseDuration(input, {now: now}))).is.true;
         });
     });

--- a/test/calendar-expression-asts.spec.js
+++ b/test/calendar-expression-asts.spec.js
@@ -9,6 +9,7 @@ describe('CalendarExpression parsing as AST', function() {
     var tests = {
         'this year': {
             type: 'CalendarExpression',
+            valueType: 'moment',
             direction: 'down',
             unit: 'year',
             expression: {
@@ -17,15 +18,18 @@ describe('CalendarExpression parsing as AST', function() {
         },
         'month of 2015-01-01T01:02:03.456': {
             type: 'CalendarExpression',
+            valueType: 'moment',
             direction: 'down',
             unit: 'month',
             expression: {
                 type: 'ISODateLiteral',
+                valueType: 'moment',
                 value: '2015-01-01T01:02:03.456'
             }
         },
         'final month of this year': {
             type: 'CalendarExpression',
+            valueType: 'moment',
             direction: 'down',
             unit: 'month',
             expression: {
@@ -34,6 +38,7 @@ describe('CalendarExpression parsing as AST', function() {
                 unit: 'year',
                 expression: {
                     type: 'CalendarExpression',
+                    valueType: 'moment',
                     direction: 'down',
                     unit: 'year',
                     expression: {
@@ -44,6 +49,7 @@ describe('CalendarExpression parsing as AST', function() {
         },
         'final day of month of 2015-01-01T01:02:03.456': {
             type: 'CalendarExpression',
+            valueType: 'moment',
             direction: 'down',
             unit: 'day',
             expression: {
@@ -52,10 +58,12 @@ describe('CalendarExpression parsing as AST', function() {
                 unit: 'month',
                 expression: {
                     type: 'CalendarExpression',
+                    valueType: 'moment',
                     direction: 'down',
                     unit: 'month',
                     expression: {
                         type: 'ISODateLiteral',
+                        valueType: 'moment',
                         value: '2015-01-01T01:02:03.456'
                     }
                 }

--- a/test/calendar-expressions.spec.js
+++ b/test/calendar-expressions.spec.js
@@ -21,6 +21,7 @@ describe('CalendarExpression parsing as moment', function() {
 
     _.each(tests, function(expected, input) {
         it('handles "' + input + '"', function() {
+            expect(parser.parse(input).valueType).equal('moment');
             expect(parser.parseMoment(input, {now: now}).isSame(expected)).is.true;
         });
     });

--- a/test/duration-expressions.spec.js
+++ b/test/duration-expressions.spec.js
@@ -17,6 +17,7 @@ describe('Full duration grammar expression parsing', function() {
 
     _.each(tests, function(duration, input) {
         it('handles "' + input + '"', function() {
+            expect(parser.parse(input).valueType).equal('duration');
             expect(parser.parseDuration(input)).deep.equal(duration);
         });
     });

--- a/test/duration-literal-asts.spec.js
+++ b/test/duration-literal-asts.spec.js
@@ -9,65 +9,77 @@ describe('literal duration parsing as AST', function() {
     var tests = {
         '1 hour': {
             type: 'MomentDuration',
+            valueType: 'duration',
             unit: "hour",
             value: 1
         },
 
         '100 s': {
             type: 'MomentDuration',
+            valueType: 'duration',
             unit: "s",
             value: 100
         },
 
         '1.5d': {
             type: 'MomentDuration',
+            valueType: 'duration',
             unit: "d",
             value: 1.5
         },
 
         '1m': {
             type: 'MomentDuration',
+            valueType: 'duration',
             unit: "m",
             value: 1
         },
 
         '12 M': {
             type: 'MomentDuration',
+            valueType: 'duration',
             unit: "M",
             value: 12
         },
 
         'P1W': {
             type: 'ISODurationLiteral',
+            valueType: 'duration',
             value: 'P1W'
         },
 
         'P1Y2M3DT4H5M6S': {
             type: 'ISODurationLiteral',
+            valueType: 'duration',
             value: 'P1Y2M3DT4H5M6S'
         },
 
         'PT4H5M': {
             type: 'ISODurationLiteral',
+            valueType: 'duration',
             value: 'PT4H5M'
         },
 
         'P1Y2M': {
             type: 'ISODurationLiteral',
+            valueType: 'duration',
             value: 'P1Y2M'
         },
 
         'P2MT5M': {
             type: 'ISODurationLiteral',
+            valueType: 'duration',
             value: 'P2MT5M'
         },
 
         'forever': {
             type: 'ForeverLiteral',
+            valueType: 'duration'
         },
 
         '01:23:45': {
             type: 'TimeSpan',
+            valueType: 'duration',
             milliseconds: 0,
             seconds: 45,
             minutes: 23,
@@ -78,6 +90,7 @@ describe('literal duration parsing as AST', function() {
 
         '1/23.01:23:45.067': {
             type: 'TimeSpan',
+            valueType: 'duration',
             milliseconds: 67,
             seconds: 45,
             minutes: 23,

--- a/test/duration-literals.spec.js
+++ b/test/duration-literals.spec.js
@@ -26,6 +26,7 @@ describe('literal duration parsing as durations', function() {
 
     _.each(tests, function(duration, input) {
         it('handles "' + input + '"', function() {
+            expect(parser.parse(input).valueType).equal('duration');
             expect(parser.parseDuration(input)).deep.equal(duration);
         });
     });

--- a/test/moment-expressions.spec.js
+++ b/test/moment-expressions.spec.js
@@ -29,6 +29,7 @@ describe('Full moment grammar expression parsing', function() {
 
     _.each(tests, function(expected, input) {
         it('handles "' + input + '"', function() {
+            expect(parser.parse(input).valueType).equal('moment');
             expect(parser.parseMoment(input, {now: now}).isSame(expected)).is.true;
         });
     });

--- a/test/moment-literal-asts.spec.js
+++ b/test/moment-literal-asts.spec.js
@@ -10,37 +10,45 @@ var now = moment.utc('2015-01-01');
 describe('literal moment parsing as AST', function() {
     var tests = {
         'beginning': {
-            type: 'BeginningLiteral'
+            type: 'BeginningLiteral',
+            valueType: 'moment'
         },
 
         '300': {
             type: 'UnixTimeLiteral',
+            valueType: 'moment',
             value: 300
         },
 
         '2015-01-01': {
             type: 'ISODateLiteral',
+            valueType: 'moment',
             value: "2015-01-01T00:00:00"
         },
 
         'yesterday': {
-            type: 'YesterdayLiteral'
+            type: 'YesterdayLiteral',
+            valueType: 'moment'
         },
 
         'today': {
-            type: 'TodayLiteral'
+            type: 'TodayLiteral',
+            valueType: 'moment'
         },
 
         'now': {
-            type: 'NowLiteral'
+            type: 'NowLiteral',
+            valueType: 'moment'
         },
 
         'tomorrow': {
-            type: 'TomorrowLiteral'
+            type: 'TomorrowLiteral',
+            valueType: 'moment'
         },
 
         'end': {
-            type: 'EndLiteral'
+            type: 'EndLiteral',
+            valueType: 'moment'
         }
     };
 

--- a/test/moment-literals.spec.js
+++ b/test/moment-literals.spec.js
@@ -19,6 +19,7 @@ describe('literal moment parsing as moments', function() {
 
     _.each(tests, function(expected, input) {
         it('handles "' + input + '"', function() {
+            expect(parser.parse(input).valueType).equal('moment');
             var m = parser.parseMoment(input, {now: now});
             expect(m.isSame(expected)).is.true;
         });


### PR DESCRIPTION
As part of constructing the AST, include an attribute for the node
that indicates whether the object is a moment or a duration. This
enables a caller to look at the top-level AST node and determine
the type of the underlying value.