### PR TITLE
api: expose generateMoment and generateDuration functions

### DIFF
--- a/lib/moment-parser.js
+++ b/lib/moment-parser.js
@@ -28,6 +28,17 @@ var MomentParser = Base.extend({
      */
     parseMoment: function(source, options) {
         var ast = this.parse(source);
+        return this.generateMoment(ast, options);
+    },
+
+    /*
+     * Given an AST, generate a moment object based on the parse tree.
+     *
+     * To support expressions that are relative to a "current" time, options.now
+     * may contain a moment instance for the current time. It defaults
+     * to the time of execution.
+     */
+    generateMoment: function(ast, options) {
         var moment = new MomentGenerator(options).visit(ast);
         if (!moment._isAMomentObject) {
             throw new errors.NotAMomentError();
@@ -41,13 +52,19 @@ var MomentParser = Base.extend({
      */
     parseDuration: function(source, options) {
         var ast = this.parse(source);
+        return this.generateDuration(ast, options);
+    },
+
+    /*
+     * Given an AST, generate a duration object based on the parse tree.
+     */
+    generateDuration: function(ast, options) {
         var duration = new MomentGenerator(options).visit(ast);
         if (duration._isAMomentObject) {
             throw new errors.NotADurationError();
         }
         return duration;
     }
-
 });
 
 module.exports = MomentParser;

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -10,11 +10,13 @@ var now = moment.utc('2015-01-01T01:02:03.456');
 describe('moment-parser API ', function() {
     it('parses moment strings and returns moments', function() {
         expect(parser.parseMoment("now", {now: now}).isSame(now)).is.true;
+        expect(parser.generateMoment(parser.parse("now"), {now: now}).isSame(now)).is.true;
     });
 
     it('parses duration strings and returns durations', function() {
         var dur = moment.duration(3, 'weeks')
         expect(parser.parseDuration("3 weeks")).deep.equal(dur);
+        expect(parser.generateDuration(parser.parse("3 weeks"))).deep.equal(dur);
     });
 
     it('rejects durations when expecting a moment', function() {


### PR DESCRIPTION
To support cases where the caller wants to split out the parse phase
from the generation phase, add external entry points to generate a
moment or duration given a parse tree.