### PR TITLE
export functions that instantiate their own MomentParsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Natural language time parser for moment.js strings
 ```npm install moment-parser```
 
 ```js
-var MomentParser = require('moment-parser');
-var parser = new MomentParser();
+var parser = require('moment-parser');
 
 // durations
 console.log(parser.parse('1 hour')); //{ type: 'MomentDuration', value: 1, unit: 'hour' }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,14 +1,10 @@
+var parser = require('./parser');
+
 function subclass(child, parent) {
     function ctor() { this.constructor = child; }
     ctor.prototype = parent.prototype;
     child.prototype = new ctor();
 }
-
-function SyntaxError(message) {
-    this.name = "SyntaxError";
-    this.message = message;
-}
-subclass(SyntaxError, Error);
 
 function NotAMomentError(message) {
     this.name = "NotAMomentError";
@@ -23,7 +19,7 @@ function NotADurationError(message) {
 subclass(NotADurationError, Error);
 
 module.exports = {
-    SyntaxError: SyntaxError,
+    SyntaxError: parser.SyntaxError,
     NotAMomentError: NotAMomentError,
     NotADurationError: NotADurationError
 };

--- a/lib/moment-parser.js
+++ b/lib/moment-parser.js
@@ -5,11 +5,6 @@ var MomentGenerator = require('./moment-generator');
 var moment = require('moment');
 
 var MomentParser = Base.extend({
-    initialize: function(options) {
-        options = options || {};
-        this.debug = !!options.debug;
-    },
-
     /*
      * Parse the given input into an AST.
      */
@@ -67,4 +62,23 @@ var MomentParser = Base.extend({
     }
 });
 
-module.exports = MomentParser;
+module.exports = {
+    parse: function(source) {
+        return new MomentParser().parse(source);
+    },
+    parseMoment: function(source, options) {
+        return new MomentParser().parseMoment(source, options);
+    },
+    parseDuration: function(source, options) {
+        return new MomentParser().parseDuration(source, options);
+    },
+    generateMoment: function(ast, options) {
+        return new MomentParser().generateMoment(ast, options);
+    },
+    generateDuration: function(ast, options) {
+        return new MomentParser().generateDuration(ast, options);
+    },
+    SyntaxError: errors.SyntaxError,
+    NotAMomentError: errors.NotAMomentError,
+    NotADurationError: errors.NotADurationError
+}

--- a/lib/moment-parser.js
+++ b/lib/moment-parser.js
@@ -1,17 +1,13 @@
-var Base = require('extendable-base');
-var parser = require('./parser');
+var peg_parser = require('./parser');
 var errors = require('./errors');
 var MomentGenerator = require('./moment-generator');
 var moment = require('moment');
 
-var MomentParser = Base.extend({
+var parser = {
     /*
      * Parse the given input into an AST.
      */
-    parse: function(source) {
-        var ast = parser.parse(source);
-        return ast;
-    },
+    parse: peg_parser.parse,
 
     /*
      * Parse the given input into an AST and generate a moment object based on
@@ -22,8 +18,8 @@ var MomentParser = Base.extend({
      * to the time of execution.
      */
     parseMoment: function(source, options) {
-        var ast = this.parse(source);
-        return this.generateMoment(ast, options);
+        var ast = parser.parse(source);
+        return parser.generateMoment(ast, options);
     },
 
     /*
@@ -46,8 +42,8 @@ var MomentParser = Base.extend({
      * the parse tree.
      */
     parseDuration: function(source, options) {
-        var ast = this.parse(source);
-        return this.generateDuration(ast, options);
+        var ast = parser.parse(source);
+        return parser.generateDuration(ast, options);
     },
 
     /*
@@ -59,26 +55,11 @@ var MomentParser = Base.extend({
             throw new errors.NotADurationError();
         }
         return duration;
-    }
-});
+    },
 
-module.exports = {
-    parse: function(source) {
-        return new MomentParser().parse(source);
-    },
-    parseMoment: function(source, options) {
-        return new MomentParser().parseMoment(source, options);
-    },
-    parseDuration: function(source, options) {
-        return new MomentParser().parseDuration(source, options);
-    },
-    generateMoment: function(ast, options) {
-        return new MomentParser().generateMoment(ast, options);
-    },
-    generateDuration: function(ast, options) {
-        return new MomentParser().generateDuration(ast, options);
-    },
     SyntaxError: errors.SyntaxError,
     NotAMomentError: errors.NotAMomentError,
     NotADurationError: errors.NotADurationError
-}
+};
+
+module.exports = parser;

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 var now = moment.utc('2015-01-01T01:02:03.456');
 
@@ -22,25 +20,12 @@ describe('moment-parser API ', function() {
     it('rejects durations when expecting a moment', function() {
         expect(function() {
             parser.parseMoment("3 weeks");
-        }).to.throw(MomentParser.NotAMomentError);
-    });
-
-    it('rejects durations when expecting a date', function() {
-        expect(function() {
-            parser.parseDate("3 weeks");
-        }).to.throw(MomentParser.NotAMomentError);
+        }).to.throw(parser.NotAMomentError);
     });
 
     it('rejects moments when expecting a duration', function() {
         expect(function() {
             parser.parseDuration("now", {now: now});
-        }).to.throw(MomentParser.NotADurationError);
+        }).to.throw(parser.NotADurationError);
     });
-
-    it('rejects moments when expecting a duration', function() {
-        expect(function() {
-            parser.parseMs("now", {now: now});
-        }).to.throw(MomentParser.NotADurationError);
-    });
-
 });

--- a/test/binary-expression-asts.spec.js
+++ b/test/binary-expression-asts.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 describe('BinaryExpression parsing as AST', function() {
     var tests = {

--- a/test/binary-expressions.spec.js
+++ b/test/binary-expressions.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 var now = moment.utc('2015-01-01');
 

--- a/test/calendar-expression-asts.spec.js
+++ b/test/calendar-expression-asts.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 describe('CalendarExpression parsing as AST', function() {
     var tests = {

--- a/test/calendar-expressions.spec.js
+++ b/test/calendar-expressions.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 var now = moment.utc('2015-01-01');
 
@@ -27,7 +25,7 @@ describe('CalendarExpression parsing as moment', function() {
     });
 
     var throws = {
-        'last week of this year': MomentParser.SyntaxError // last != final!
+        'last week of this year': parser.SyntaxError // last != final!
     };
 
     _.each(throws, function(expected, input) {

--- a/test/duration-expressions.spec.js
+++ b/test/duration-expressions.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 var now = moment.utc('2015-01-01T01:02:03.456');
 
@@ -23,8 +21,8 @@ describe('Full duration grammar expression parsing', function() {
     });
 
     var throws = {
-        '1.5 months': MomentParser.SyntaxError,
-        '1.5 years': MomentParser.SyntaxError
+        '1.5 months': parser.SyntaxError,
+        '1.5 years': parser.SyntaxError
     };
 
     _.each(throws, function(expected, input) {

--- a/test/duration-literal-asts.spec.js
+++ b/test/duration-literal-asts.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 describe('literal duration parsing as AST', function() {
     var tests = {
@@ -108,7 +106,7 @@ describe('literal duration parsing as AST', function() {
     });
 
     var throws = {
-        '32 WHA': MomentParser.SyntaxError
+        '32 WHA': parser.SyntaxError
     };
 
     _.each(throws, function(expected, input) {

--- a/test/duration-literals.spec.js
+++ b/test/duration-literals.spec.js
@@ -31,7 +31,6 @@ describe('literal duration parsing as durations', function() {
     });
 
     var throws = {
-        'forever': parser.SyntaxError,
         '0:0:0': parser.SyntaxError,
         '000:00:00': parser.SyntaxError,
         '00:00:0.123': parser.SyntaxError,

--- a/test/duration-literals.spec.js
+++ b/test/duration-literals.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 describe('literal duration parsing as durations', function() {
     var tests = {
@@ -33,12 +31,13 @@ describe('literal duration parsing as durations', function() {
     });
 
     var throws = {
-        '0:0:0': MomentParser.SyntaxError,
-        '000:00:00': MomentParser.SyntaxError,
-        '00:00:0.123': MomentParser.SyntaxError,
-        '1.5/23.01:23:45.678': MomentParser.SyntaxError,
-        '1.5/01:23:45.678': MomentParser.SyntaxError,
-        '1/23.01:23:45.0678':MomentParser.SyntaxError
+        'forever': parser.SyntaxError,
+        '0:0:0': parser.SyntaxError,
+        '000:00:00': parser.SyntaxError,
+        '00:00:0.123': parser.SyntaxError,
+        '1.5/23.01:23:45.678': parser.SyntaxError,
+        '1.5/01:23:45.678': parser.SyntaxError,
+        '1/23.01:23:45.0678':parser.SyntaxError
     };
 
     _.each(throws, function(expected, input) {

--- a/test/moment-expressions.spec.js
+++ b/test/moment-expressions.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 var now = moment.utc('2015-01-01T01:02:03.456');
 
@@ -35,8 +33,8 @@ describe('Full moment grammar expression parsing', function() {
     });
 
     var throws = {
-        'last 3 months': MomentParser.SyntaxError,
-        'next 2 days': MomentParser.SyntaxError
+        'last 3 months': parser.SyntaxError,
+        'next 2 days': parser.SyntaxError
     };
 
     _.each(throws, function(expected, input) {

--- a/test/moment-literal-asts.spec.js
+++ b/test/moment-literal-asts.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 var now = moment.utc('2015-01-01');
 
@@ -59,7 +57,7 @@ describe('literal moment parsing as AST', function() {
     });
 
     var throws = {
-        '2012/01/01': MomentParser.SyntaxError
+        '2012/01/01': parser.SyntaxError
     };
 
     _.each(throws, function(expected, input) {

--- a/test/moment-literals.spec.js
+++ b/test/moment-literals.spec.js
@@ -1,9 +1,7 @@
-var MomentParser = require('..');
+var parser = require('..');
 var _ = require('underscore');
 var expect = require('chai').expect;
 var moment = require('moment');
-
-var parser = new MomentParser();
 
 var now = moment.utc('2015-01-01');
 
@@ -26,8 +24,8 @@ describe('literal moment parsing as moments', function() {
     });
 
     var throws = {
-        'beginning': MomentParser.SyntaxError,
-        'end': MomentParser.SyntaxError
+        'beginning': parser.SyntaxError,
+        'end': parser.SyntaxError
     };
 
     _.each(throws, function(expected, input) {


### PR DESCRIPTION
Export parser/generator calls that don't require instantiating MomentParser.

@demmer: The 'throws' tests are all failing, as if suddenly the error text is being checked rather than the class. What's up with that?