### PR TITLE
make sure npm test returns with a non 0 exit code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ before_script:
 
 script:
     - npm test
+    - npm run -s check-coverage

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node_modules/.bin/istanbul cover -x 'lib/parser.js' node_modules/.bin/_mocha; node_modules/.bin/istanbul check-coverage",
+    "test": "node_modules/.bin/istanbul cover -x 'lib/parser.js' node_modules/.bin/_mocha",
+    "check-coverage": "node_modules/.bin/istanbul check-coverage",
     "postinstall": "node scripts/peg.js"
   },
   "repository": {


### PR DESCRIPTION
fixes #21 by making sure that we separate running the tests from
checking the coverage and therefore failing the run as expected when
there are test failures