### PR TITLE
add support for forever

### DIFF
--- a/lib/moment-generator.js
+++ b/lib/moment-generator.js
@@ -46,8 +46,7 @@ var MomentGenerator = ASTVisitor.extend({
     },
 
     visit_ForeverLiteral: function(node) {
-        throw new errors.SyntaxError(
-            "forever is not supported");
+        return moment.duration(Infinity);
     },
 
     visit_MomentDuration: function(node) {

--- a/test/duration-literals.spec.js
+++ b/test/duration-literals.spec.js
@@ -21,7 +21,8 @@ describe('literal duration parsing as durations', function() {
         '01:23:45': moment.duration('01:23:45'),
         '01:23:45.678': moment.duration('01:23:45.678'),
         '23.01:23:45.067': moment.duration('23.01:23:45.067'),
-        '1/23.01:23:45.067': moment.duration('23.01:23:45.067').add(1, 'M')
+        '1/23.01:23:45.067': moment.duration('23.01:23:45.067').add(1, 'M'),
+        'forever': moment.duration(Infinity)
     };
 
     _.each(tests, function(duration, input) {
@@ -32,7 +33,6 @@ describe('literal duration parsing as durations', function() {
     });
 
     var throws = {
-        'forever': MomentParser.SyntaxError,
         '0:0:0': MomentParser.SyntaxError,
         '000:00:00': MomentParser.SyntaxError,
         '00:00:0.123': MomentParser.SyntaxError,


### PR DESCRIPTION
Instead of throwing an error when parsing 'forever', generate an infinite duration.