### PR TITLE
support beginning and end

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,14 +1,10 @@
+var parser = require('./parser');
+
 function subclass(child, parent) {
     function ctor() { this.constructor = child; }
     ctor.prototype = parent.prototype;
     child.prototype = new ctor();
 }
-
-function SyntaxError(message) {
-    this.name = "SyntaxError";
-    this.message = message;
-}
-subclass(SyntaxError, Error);
 
 function NotAMomentError(message) {
     this.name = "NotAMomentError";
@@ -23,7 +19,7 @@ function NotADurationError(message) {
 subclass(NotADurationError, Error);
 
 module.exports = {
-    SyntaxError: SyntaxError,
+    SyntaxError: parser.SyntaxError,
     NotAMomentError: NotAMomentError,
     NotADurationError: NotADurationError
 };

--- a/lib/moment-generator.js
+++ b/lib/moment-generator.js
@@ -24,13 +24,11 @@ var MomentGenerator = ASTVisitor.extend({
     },
 
     visit_BeginningLiteral: function(node) {
-        throw new errors.SyntaxError(
-            "beginning is not supported for moments");
+        return moment.utc(-Infinity);
     },
 
     visit_EndLiteral: function(node) {
-        throw new errors.SyntaxError(
-            "end is not supported for moments");
+        return moment.utc(Infinity);
     },
 
     visit_YesterdayLiteral: function(node) {

--- a/test/moment-literals.spec.js
+++ b/test/moment-literals.spec.js
@@ -14,20 +14,25 @@ describe('literal moment parsing as moments', function() {
         'yesterday': now.clone().startOf('day').subtract(1, 'day'),
         'today': now.clone().startOf('day'),
         'now': now,
-        'tomorrow': now.clone().startOf('day').add(1, 'day')
+        'tomorrow': now.clone().startOf('day').add(1, 'day'),
+        'beginning': moment.utc(-Infinity),
+        'end': moment.utc(Infinity),
     };
 
     _.each(tests, function(expected, input) {
         it('handles "' + input + '"', function() {
             expect(parser.parse(input).valueType).equal('moment');
             var m = parser.parseMoment(input, {now: now});
-            expect(m.isSame(expected)).is.true;
+            if (! isNaN(m.valueOf())) {
+                expect(m.isSame(expected)).is.true;
+            } else {
+                expect(m._i).equal(expected._i);
+            }
         });
     });
 
     var throws = {
-        'beginning': MomentParser.SyntaxError,
-        'end': MomentParser.SyntaxError
+        'garbage': MomentParser.SyntaxError,
     };
 
     _.each(throws, function(expected, input) {


### PR DESCRIPTION
Finish the job started in #24 by adding support for `beginning` and `end`. These generate moments that wrap -Infinity or Infinity respectively.

This also requires removing the now unused `SyntaxError` class from lib/errors since otherwise travis complained about code coverage not being 100%, which will need to be reconciled with #20 since they both do the same thing.


