### PR TITLE
use moment.isMoment() rather than referencing ._isAMomentObject

### DIFF
--- a/lib/moment-parser.js
+++ b/lib/moment-parser.js
@@ -30,11 +30,11 @@ var parser = {
      * to the time of execution.
      */
     generateMoment: function(ast, options) {
-        var moment = new MomentGenerator(options).visit(ast);
-        if (!moment._isAMomentObject) {
+        var m = new MomentGenerator(options).visit(ast);
+        if (!moment.isMoment(m)) {
             throw new errors.NotAMomentError();
         }
-        return moment;
+        return m;
     },
 
     /*
@@ -51,7 +51,7 @@ var parser = {
      */
     generateDuration: function(ast, options) {
         var duration = new MomentGenerator(options).visit(ast);
-        if (duration._isAMomentObject) {
+        if (moment.isMoment(duration)) {
             throw new errors.NotADurationError();
         }
         return duration;


### PR DESCRIPTION
just what it says. @demmer 