### PR TITLE
add support for beginning and end

### DIFF
--- a/lib/moment-generator.js
+++ b/lib/moment-generator.js
@@ -8,7 +8,10 @@ var moment = require('moment');
  */
 var MomentGenerator = ASTVisitor.extend({
     initialize: function(options) {
-        this.now = options && options.now || moment.utc();
+        options = options || {};
+        this.now = options.now || moment.utc();
+        this.beginning = options.beginning || moment.utc(-100 * 1000000 * 1000 * 24 * 3600);
+        this.end = options.end || moment.utc(100 * 1000000 * 1000 * 24 * 3600);
     },
 
     visit_ISODateLiteral: function(node) {
@@ -24,11 +27,11 @@ var MomentGenerator = ASTVisitor.extend({
     },
 
     visit_BeginningLiteral: function(node) {
-        return moment.utc(-100 * 1000000 * 1000 * 24 * 3600)
+        return this.beginning.clone();
     },
 
     visit_EndLiteral: function(node) {
-        return moment.utc(100 * 1000000 * 1000 * 24 * 3600)
+        return this.end.clone();
     },
 
     visit_YesterdayLiteral: function(node) {

--- a/lib/moment-generator.js
+++ b/lib/moment-generator.js
@@ -24,13 +24,11 @@ var MomentGenerator = ASTVisitor.extend({
     },
 
     visit_BeginningLiteral: function(node) {
-        throw new errors.SyntaxError(
-            "beginning is not supported for moments");
+        return moment.utc(-100 * 1000000 * 1000 * 24 * 3600)
     },
 
     visit_EndLiteral: function(node) {
-        throw new errors.SyntaxError(
-            "end is not supported for moments");
+        return moment.utc(100 * 1000000 * 1000 * 24 * 3600)
     },
 
     visit_YesterdayLiteral: function(node) {

--- a/test/moment-literals.spec.js
+++ b/test/moment-literals.spec.js
@@ -7,6 +7,8 @@ var now = moment.utc('2015-01-01');
 
 describe('literal moment parsing as moments', function() {
     var tests = {
+        'beginning': moment.utc(-100 * 1000000 * 1000 * 24 * 3600),
+        'end': moment.utc(100 * 1000000 * 1000 * 24 * 3600),
         '300': moment.utc(300 * 1000),
         '2015-01-01': moment.utc('2015-01-01'),
         'yesterday': now.clone().startOf('day').subtract(1, 'day'),
@@ -19,21 +21,8 @@ describe('literal moment parsing as moments', function() {
         it('handles "' + input + '"', function() {
             expect(parser.parse(input).valueType).equal('moment');
             var m = parser.parseMoment(input, {now: now});
+            expect(m.toISOString()).equal(expected.toISOString());
             expect(m.isSame(expected)).is.true;
-        });
-    });
-
-    var throws = {
-        'beginning': parser.SyntaxError,
-        'end': parser.SyntaxError
-    };
-
-    _.each(throws, function(expected, input) {
-        it('fails on "' + input + '"', function() {
-            function parseInput() {
-                parser.parseMoment(input);
-            }
-            expect(parseInput).to.throw(expected);
         });
     });
 });

--- a/test/moment-literals.spec.js
+++ b/test/moment-literals.spec.js
@@ -25,4 +25,26 @@ describe('literal moment parsing as moments', function() {
             expect(m.isSame(expected)).is.true;
         });
     });
+
+    it('allows the beginning / end value to be overridden', function() {
+        var m;
+
+        m = parser.parseMoment('beginning', {beginning: moment.utc(-Infinity)});
+        expect(m.valueOf().toString()).equals('NaN');
+        expect(m._i).equals(-Infinity);
+
+        m = parser.parseMoment('beginning', {beginning: moment.utc(0)});
+        expect(m.toISOString()).equals('1970-01-01T00:00:00.000Z');
+        expect(m.valueOf().toString()).equals('0');
+
+        m = parser.parseMoment('end', {end: moment.utc('1234-05-06')});
+        expect(m.toISOString()).equals('1234-05-06T00:00:00.000Z');
+
+        m = parser.parseMoment('end', {end: moment.utc('6543-02-01')});
+        expect(m.toISOString()).equals('6543-02-01T00:00:00.000Z');
+
+        m = parser.parseMoment('end', {end: moment.utc(Infinity)});
+        expect(m.valueOf().toString()).equals('NaN');
+        expect(m._i).equals(Infinity);
+    });
 });


### PR DESCRIPTION
Instead of throwing an error when generating moments for `beginning` or `end`,
generate the limits of a javascript Date, i.e. the epoch +/- 100M days.

This is the alternative approach suggested by @welch in #25 